### PR TITLE
Updated to work with PDFMiner 20181108

### DIFF
--- a/layout_scanner.py
+++ b/layout_scanner.py
@@ -25,11 +25,9 @@ def with_pdf (pdf_doc, fn, pdf_pwd, *args):
         # create a parser object associated with the file object
         parser = PDFParser(fp)
         # create a PDFDocument object that stores the document structure
-        doc = PDFDocument(parser)
+        doc = PDFDocument(parser, pdf_pwd)
         # connect the parser and document objects
         parser.set_document(doc)
-        # supply the password for initialization
-        doc.initialize(pdf_pwd)
 
         if doc.is_extractable:
             # apply the function and return the result


### PR DESCRIPTION
There is no more `initialize()` method; instead, the password can be passed to the constructor